### PR TITLE
Add a failing test for `snake()` method

### DIFF
--- a/Tests/AbstractAsciiTestCase.php
+++ b/Tests/AbstractAsciiTestCase.php
@@ -1034,6 +1034,7 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['', ''],
             ['symfony_is_great', 'symfonyIsGreat'],
             ['symfony5_is_great', 'symfony5IsGreat'],
+            ['symfony_5_is_great', 'symfony_5_Is_Great'],
             ['symfony5is_great', 'symfony5isGreat'],
             ['symfony_is_great', 'Symfony is great'],
             ['symfony_is_a_great_framework', 'symfonyIsAGreatFramework'],


### PR DESCRIPTION
Hi guys!
It seems to me that the `snake()` method doesn't work as it should in certain cases.
I've added a failing test to illustrate it.