### PR TITLE
Add missing return type to AsciiSlugger::getLocale()

### DIFF
--- a/Slugger/AsciiSlugger.php
+++ b/Slugger/AsciiSlugger.php
@@ -90,7 +90,7 @@ class AsciiSlugger implements SluggerInterface, LocaleAwareInterface
     /**
      * {@inheritdoc}
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->defaultLocale;
     }


### PR DESCRIPTION
Got the following issue this morning in symfony 5.4-RC1 with php 8.1:
```
!!  
!!  Fatal error: Declaration of Symfony\Component\String\Slugger\AsciiSlugger::getLocale() must be compatible with Symfony\Contracts\Translation\LocaleAwareInterface::getLocale(): string in /opt/project/vendor/symfony/string/Slugger/AsciiSlugger.php on line 93
!!  Symfony\Component\ErrorHandler\Error\FatalError {#6153
!!    #message: "Compile Error: Declaration of Symfony\Component\String\Slugger\AsciiSlugger::getLocale() must be compatible with Symfony\Contracts\Translation\LocaleAwareInterface::getLocale(): string"
!!    #code: 0
!!    #file: "./vendor/symfony/string/Slugger/AsciiSlugger.php"
!!    #line: 93
!!    -error: array:4 [
!!      "type" => 64
!!      "message" => "Declaration of Symfony\Component\String\Slugger\AsciiSlugger::getLocale() must be compatible with Symfony\Contracts\Translation\LocaleAwareInterface::getLocale(): string"
!!      "file" => "/opt/project/vendor/symfony/string/Slugger/AsciiSlugger.php"
!!      "line" => 93
!!    ]
!!  }
!!  
```