### PR TITLE
Require intl extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-intl-grapheme": "~1.0",
         "symfony/polyfill-intl-normalizer": "~1.0",
-        "symfony/polyfill-mbstring": "~1.0"
+        "symfony/polyfill-mbstring": "~1.0",
+        "ext-intl": "*"
     },
     "require-dev": {
         "symfony/error-handler": "^5.4|^6.0",


### PR DESCRIPTION
When disabling polyfills, it was discovered that this library requires the `intl` extension, which is usually not installed by default. This PR adds it as a requirement (that can easily be bypassed in composer), but makes it clear there is a dependency on an extension that is more performant than the polyfill.